### PR TITLE
Fix Rust compilation errors in crypto module

### DIFF
--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -46,7 +46,7 @@ pub struct VerifiedKey {
     pub verified_at: i64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct KeyPair {
     pub public: PublicKey,
     pub secret: StaticSecret,
@@ -79,7 +79,7 @@ impl KeyPair {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SigningKeyPair {
     pub verifying: VerifyingKey,
     pub signing: SigningKey,


### PR DESCRIPTION
Issues fixed:
1. Removed Debug derive from KeyPair and SigningKeyPair structs
   - StaticSecret and SigningKey don't implement Debug trait
   - Kept Clone derive as it's needed

2. Fixed HMAC trait ambiguity errors
   - Multiple Mac trait implementations were in scope
   - Used explicit turbofish syntax: <Hmac::<Sha256> as HmacMac>::new_from_slice
   - Imported Mac trait as HmacMac to avoid conflicts

These fixes resolve all compilation errors while maintaining the cryptographic functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)